### PR TITLE
feat: tv component definition w/ config overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:watch": "jest --watch --no-verbose"
   },
   "dependencies": {
+    "defu": "6.1.4",
     "tailwind-merge": "2.5.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      defu:
+        specifier: 6.1.4
+        version: 6.1.4
       tailwind-merge:
         specifier: 2.5.4
         version: 2.5.4
@@ -1774,6 +1777,9 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  defu@6.1.4:
+    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
@@ -5485,6 +5491,8 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  defu@6.1.4: {}
+
   detect-newline@3.1.0: {}
 
   didyoumean@1.2.2: {}
@@ -5677,7 +5685,7 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 8.57.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.14.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.14.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.14.0(eslint@8.57.0)(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@8.57.0))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -5690,7 +5698,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.14.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.14.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.14.0(eslint@8.57.0)(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -5718,7 +5726,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.14.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.14.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.14.0(eslint@8.57.0)(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3

--- a/src/__tests__/defineTV.test.ts
+++ b/src/__tests__/defineTV.test.ts
@@ -1,0 +1,124 @@
+import {expect, describe} from "@jest/globals";
+
+import {defineTV} from "../index";
+
+const createTestComponent = defineTV({
+  base: "base",
+  slots: {
+    a: "apples",
+    b: "bananas",
+  },
+  variants: {
+    size: {
+      small: {
+        a: "small-apples",
+        b: "small-bananas",
+      },
+      medium: {
+        a: "medium-apples",
+        b: "medium-bananas",
+      },
+      large: {
+        a: "large-apples",
+        b: "large-bananas",
+      },
+    },
+    rotten: {
+      true: {
+        a: "rotten-apples",
+        b: "rotten-bananas",
+      },
+      false: {
+        a: "fresh-apples",
+        b: "fresh-bananas",
+      },
+    },
+  },
+  compoundSlots: [
+    {
+      slots: ["a", "b"],
+      size: "medium",
+      class: "slot-compound",
+    },
+  ],
+  compoundVariants: [
+    {
+      disabled: false,
+      size: "medium",
+      class: {a: "variant-compound"},
+    },
+  ],
+  defaultVariants: {
+    size: "medium",
+    disabled: false,
+  },
+});
+
+describe("defineTV", () => {
+  it("should define a basic TV component", () => {
+    const component = createTestComponent();
+
+    ["a", "b", "base"].forEach((key) => expect(component).toHaveProperty(key));
+    expect(component.base()).toStrictEqual("base");
+    expect(component.a()).toStrictEqual(
+      "apples medium-apples fresh-apples variant-compound slot-compound",
+    );
+    expect(component.b()).toStrictEqual("bananas medium-bananas fresh-bananas slot-compound");
+  });
+
+  it("enables slot overrides", () => {
+    const component = createTestComponent({slots: {a: "oranges", b: "pears"}});
+
+    expect(component.a()).toStrictEqual(
+      "oranges medium-apples fresh-apples variant-compound slot-compound",
+    );
+    expect(component.b()).toStrictEqual("pears medium-bananas fresh-bananas slot-compound");
+  });
+
+  it("enables variant overrides", () => {
+    const component = createTestComponent({
+      variants: {size: {medium: {a: "medium-oranges", b: "medium-pears"}}},
+    });
+
+    expect(component.a()).toStrictEqual(
+      "apples medium-oranges fresh-apples variant-compound slot-compound",
+    );
+    expect(component.b()).toStrictEqual("bananas medium-pears fresh-bananas slot-compound");
+  });
+
+  it("enables compound slot overrides", () => {
+    const component = createTestComponent({
+      compoundSlots: [{slots: ["a", "b"], size: "medium", class: "slot-element"}],
+    });
+
+    expect(component.a()).toStrictEqual(
+      "apples medium-apples fresh-apples variant-compound slot-element",
+    );
+    expect(component.b()).toStrictEqual("bananas medium-bananas fresh-bananas slot-element");
+  });
+
+  it("enables compound variant overrides", () => {
+    const component = createTestComponent({
+      compoundVariants: [{rotten: false, size: "medium", class: {a: "variant-element"}}],
+    });
+
+    expect(component.a()).toStrictEqual(
+      "apples medium-apples fresh-apples variant-element slot-compound",
+    );
+    expect(component.b()).toStrictEqual("bananas medium-bananas fresh-bananas slot-compound");
+  });
+
+  it("enables default variant overrides", () => {
+    const component = createTestComponent({defaultVariants: {size: "small", rotten: true}});
+
+    expect(component.a()).toStrictEqual("apples small-apples rotten-apples");
+    expect(component.b()).toStrictEqual("bananas small-bananas rotten-bananas");
+  });
+
+  it("passes props to the component", () => {
+    const component = createTestComponent({}, {size: "large", rotten: true});
+
+    expect(component.a()).toStrictEqual("apples large-apples rotten-apples");
+    expect(component.b()).toStrictEqual("bananas large-bananas rotten-bananas");
+  });
+});

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -225,6 +225,111 @@ export type TVReturnType<
     : string;
 } & TVReturnProps<V, S, B, EV, ES, E>;
 
+export type TVOptions<
+  V extends TVVariants<S, B, EV>,
+  CV extends TVCompoundVariants<V, S, B, EV, ES>,
+  DV extends TVDefaultVariants<V, S, EV, ES>,
+  C extends TVConfig<V, EV>,
+  B extends ClassValue = undefined,
+  S extends TVSlots = undefined,
+  // @ts-expect-error
+  E extends TVReturnType = TVReturnType<
+    V,
+    S,
+    B,
+    C,
+    // @ts-expect-error
+    EV extends undefined ? {} : EV,
+    // @ts-expect-error
+    ES extends undefined ? {} : ES
+  >,
+  EV extends TVVariants<ES, B, E["variants"], ES> = E["variants"],
+  ES extends TVSlots = E["slots"] extends TVSlots ? E["slots"] : undefined,
+> = {
+  /**
+   * Extend allows for easy composition of components.
+   * @see https://www.tailwind-variants.org/docs/composing-components
+   */
+  extend?: E;
+  /**
+   * Base allows you to set a base class for a component.
+   */
+  base?: B;
+  /**
+   * Slots allow you to separate a component into multiple parts.
+   * @see https://www.tailwind-variants.org/docs/slots
+   */
+  slots?: S;
+  /**
+   * Variants allow you to create multiple versions of the same component.
+   * @see https://www.tailwind-variants.org/docs/variants#adding-variants
+   */
+  variants?: V;
+  /**
+   * Compound variants allow you to apply classes to multiple variants at once.
+   * @see https://www.tailwind-variants.org/docs/variants#compound-variants
+   */
+  compoundVariants?: CV;
+  /**
+   * Compound slots allow you to apply classes to multiple slots at once.
+   */
+  compoundSlots?: TVCompoundSlots<V, S, B>;
+  /**
+   * Default variants allow you to set default variants for a component.
+   * @see https://www.tailwind-variants.org/docs/variants#default-variants
+   */
+  defaultVariants?: DV;
+};
+
+export type TVOverride<
+  V extends TVVariants<S, B, EV>,
+  C extends TVConfig<V, EV>,
+  B extends ClassValue = undefined,
+  S extends TVSlots = undefined,
+  // @ts-expect-error
+  E extends TVReturnType = TVReturnType<
+    V,
+    S,
+    B,
+    C,
+    // @ts-expect-error
+    EV extends undefined ? {} : EV,
+    // @ts-expect-error
+    ES extends undefined ? {} : ES
+  >,
+  EV extends TVVariants<ES, B, E["variants"], ES> = E["variants"],
+  ES extends TVSlots = E["slots"] extends TVSlots ? E["slots"] : undefined,
+> = {
+  /**
+   * Slots allow you to override the slot config of a component
+   */
+  slots?: S extends TVSlots ? {[KS in keyof S]?: ClassValue} : never;
+  /**
+   * Variants allow you to override the variant config of a component
+   */
+  variants?: {
+    [KV in keyof V]?: {
+      [OV in keyof V[KV]]?: S extends TVSlots
+        ? {
+            [KS in keyof S]?: ClassValue;
+          }
+        : ClassValue;
+    };
+  };
+  /**
+   * Compound variants allow you to override the compound variant config of a component
+   */
+  compoundVariants?: TVCompoundVariants<V, S, B, EV, ES>;
+  /**
+   * Compound slots allow you to override the compound slot config of a components
+   */
+  compoundSlots?: TVCompoundSlots<V, S, B>;
+  /**
+   * Default variants allow you to override the default variant config of a component
+   */
+  defaultVariants?: TVDefaultVariants<V, S, EV, ES>;
+};
+
 export type TV = {
   <
     V extends TVVariants<S, B, EV>,
@@ -247,41 +352,11 @@ export type TV = {
     EV extends TVVariants<ES, B, E["variants"], ES> = E["variants"],
     ES extends TVSlots = E["slots"] extends TVSlots ? E["slots"] : undefined,
   >(
-    options: {
-      /**
-       * Extend allows for easy composition of components.
-       * @see https://www.tailwind-variants.org/docs/composing-components
-       */
-      extend?: E;
-      /**
-       * Base allows you to set a base class for a component.
-       */
-      base?: B;
-      /**
-       * Slots allow you to separate a component into multiple parts.
-       * @see https://www.tailwind-variants.org/docs/slots
-       */
-      slots?: S;
-      /**
-       * Variants allow you to create multiple versions of the same component.
-       * @see https://www.tailwind-variants.org/docs/variants#adding-variants
-       */
-      variants?: V;
-      /**
-       * Compound variants allow you to apply classes to multiple variants at once.
-       * @see https://www.tailwind-variants.org/docs/variants#compound-variants
-       */
-      compoundVariants?: CV;
-      /**
-       * Compound slots allow you to apply classes to multiple slots at once.
-       */
-      compoundSlots?: TVCompoundSlots<V, S, B>;
-      /**
-       * Default variants allow you to set default variants for a component.
-       * @see https://www.tailwind-variants.org/docs/variants#default-variants
-       */
-      defaultVariants?: DV;
-    },
+    /**
+     * The options object allows you to define the component.
+     * @see https://www.tailwind-variants.org/docs/api-reference#options
+     */
+    options: TVOptions<V, CV, DV, C, B, S, E, EV, ES>,
     /**
      * The config object allows you to modify the default configuration.
      * @see https://www.tailwind-variants.org/docs/api-reference#config-optional
@@ -312,41 +387,7 @@ export type CreateTV<RV extends TVConfig["responsiveVariants"] = undefined> = {
     EV extends TVVariants<ES, B, E["variants"], ES> = E["variants"],
     ES extends TVSlots = E["slots"] extends TVSlots ? E["slots"] : undefined,
   >(
-    options: {
-      /**
-       * Extend allows for easy composition of components.
-       * @see https://www.tailwind-variants.org/docs/composing-components
-       */
-      extend?: E;
-      /**
-       * Base allows you to set a base class for a component.
-       */
-      base?: B;
-      /**
-       * Slots allow you to separate a component into multiple parts.
-       * @see https://www.tailwind-variants.org/docs/slots
-       */
-      slots?: S;
-      /**
-       * Variants allow you to create multiple versions of the same component.
-       * @see https://www.tailwind-variants.org/docs/variants#adding-variants
-       */
-      variants?: V;
-      /**
-       * Compound variants allow you to apply classes to multiple variants at once.
-       * @see https://www.tailwind-variants.org/docs/variants#compound-variants
-       */
-      compoundVariants?: CV;
-      /**
-       * Compound slots allow you to apply classes to multiple slots at once.
-       */
-      compoundSlots?: TVCompoundSlots<V, S, B>;
-      /**
-       * Default variants allow you to set default variants for a component.
-       * @see https://www.tailwind-variants.org/docs/variants#default-variants
-       */
-      defaultVariants?: DV;
-    },
+    options: TVOptions<V, CV, DV, C, B, S, E, EV, ES>,
     /**
      * The config object allows you to modify the default configuration.
      * @see https://www.tailwind-variants.org/docs/api-reference#config-optional
@@ -355,12 +396,60 @@ export type CreateTV<RV extends TVConfig["responsiveVariants"] = undefined> = {
   ): TVReturnType<V, S, B, C & RV, EV, ES, E>;
 };
 
+export type DefineTVTemplate = {
+  <
+    V extends TVVariants<S, B, EV>,
+    CV extends TVCompoundVariants<V, S, B, EV, ES>,
+    DV extends TVDefaultVariants<V, S, EV, ES>,
+    C extends TVConfig<V, EV>,
+    B extends ClassValue = undefined,
+    S extends TVSlots = undefined,
+    // @ts-expect-error
+    E extends TVReturnType = TVReturnType<
+      V,
+      S,
+      B,
+      C,
+      // @ts-expect-error
+      EV extends undefined ? {} : EV,
+      // @ts-expect-error
+      ES extends undefined ? {} : ES
+    >,
+    EV extends TVVariants<ES, B, E["variants"], ES> = E["variants"],
+    ES extends TVSlots = E["slots"] extends TVSlots ? E["slots"] : undefined,
+  >(
+    /**
+     * The template object allows you to define a component spec.
+     * @see https://www.tailwind-variants.org/docs/api-reference#template
+     */
+    template: TVOptions<V, CV, DV, C, B, S, E, EV, ES>,
+    /**
+     * The config object allows you to modify the default configuration.
+     * @see https://www.tailwind-variants.org/docs/api-reference#config-optional
+     */
+    config?: C,
+  ): (
+    /**
+     * The override object allows you to override the component template.
+     * @see https://www.tailwind-variants.org/docs/api-reference#override-optional
+     */
+    override?: TVOverride<V, C, B, S, E, EV, ES>,
+    /**
+     * The props object allows you to pass props to the component.
+     * @see https://www.tailwind-variants.org/docs/api-reference#props-optional
+     */
+    props?: TVProps<V, S, C, EV, ES>,
+  ) => ReturnType<TVReturnType<V, S, B, C, EV, ES, E>>;
+};
+
 // main function
 export declare const tv: TV;
 
 export declare function createTV<T extends TVConfig["responsiveVariants"]>(
   config: TVConfig & T,
 ): CreateTV<T>;
+
+export declare const defineTV: DefineTVTemplate;
 
 export declare const defaultConfig: TVConfig;
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import {
   isEmptyObject,
   falsyToString,
   mergeObjects,
+  mergeOptions,
   removeExtraSpaces,
   flatMergeArrays,
   flatArray,
@@ -79,7 +80,7 @@ export const tv = (options, configProp) => {
   const base = extend?.base ? cnBase(extend.base, options?.base) : options?.base;
   const variants =
     extend?.variants && !isEmptyObject(extend.variants)
-      ? mergeObjects(variantsProps, extend.variants)
+      ? mergeObjects(extend.variants, variantsProps)
       : variantsProps;
   const defaultVariants =
     extend?.defaultVariants && !isEmptyObject(extend.defaultVariants)
@@ -453,5 +454,11 @@ export const tv = (options, configProp) => {
 };
 
 export const createTV = (configProp) => {
-  return (options, config) => tv(options, config ? mergeObjects(configProp, config) : configProp);
+  return (options, config) => tv(options, config ? mergeObjects(config, configProp) : configProp);
+};
+
+export const defineTV = (options, config) => (override, props) => {
+  const template = override ? mergeOptions(override, options) : options;
+
+  return tv(template, config)(props);
 };


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I use `tailwind-variants` to help write a top-level component library that will be used to implement a number of apps across my company.  One requirement is that a given component may have different styling depending on what app it is a part of, but the core functionality should not change. This means that I need to be able to override class definitions w/ a prop.

Currently, my only option to extend/override the style is to use a "class" prop to supply alternate styling via the `class` prop in `tv`. To help illustrate what I mean, imagine we have a simple button component:

```vue
<script setup lang="ts">
const { class } = defineProps<{
  class?: { [K in "base" | "icon" | "label"]?: string }
}>();

const ui = tv({
  base: "base-class",
  slots: {
    icon: "icon-class",
    label: "label-class"
  }
})
</script>

<template>
  <button :class="ui.base({ class: class?.base })">
    <i :class="ui.icon({ class: class?.icon })" /> 
    <span :class="ui.label({ class: class?.label })">
      <slot />
    </span>
  </button>
</template>
```

This is great because my button's `tv` config needs to support a base & icon/label slots, but as this method relies on `tailwind-merge` we will always face the possibility of inheriting the classes in our original `tv` component config. What I really need is the ability to define an override that has the same structure as the original config but replaces the underlying class definitions.

This PR introduces that capability through the new `defineTV` function. I extracted the options config type for the `tv` & `createTV` functions into it's own type & added  the `defineTV` function which accepts the same initial arguments that would be passed if we were defining a `tv` object & returns another function that accepts an optional override argument along w/ the props argument to set variant types & so on. 

What this does is let us define our `tv` template in our component, accept an optional override prop from the downstream application, & instantiate a `tv` object at runtime that runs a merged config:

```vue
<script lang="ts">
const useUI = defineTV({
  base: "base-class",
  slots: {
    icon: "icon-class",
    label: "label-class"
  }
})
</script>

<script setup lang="ts">
const { 
  override,
  class
} = defineProps<{
  override?: Parameters<typeof useUI>[0];
  variants?: Parameters<typeof useUI>[1];
  class?: { [K in "base" | "icon" | "label"]?: string }
}>();

const ui = useUI(override, variants)
</script>

<template>
  <button :class="ui.base({ class: class?.base })">
    <i :class="ui.icon({ class: class?.icon })" /> 
    <span :class="ui.label({ class: class?.label })">
      <slot />
    </span>
  </button>
</template>
```

Now when I use this button in an app, I can include a `tv` configuration that is tightly coupled to the structure of the underlying component that allows for total customization of the applied classes!

### Solution 

The first step was extracting the options type that is accepted by the `tv` function into a separate type. I then defined a `TVOverride` type that accepts all of the same generic arguments as the `tv` function but the value of the type is a structure that directly reflects the root configuration.

To facilitate simpler merges, I introduced the `defu` dependency which performs recursive assignment but w/ a flexible API. I used `defu` to refactor the `mergeObjects` function as well as define a merger for the `tv` options config.

The new `defineTV` function accepts the same args `tv` does, but instead of returning the TV return type we return a function that can override the config before passing the TV return type. The result is a fully customizable component structure for layered environments!

### Notes 

I have had this working to great effect in my project for a while, so I wanted to adapt it to be a part of this package so that it can be used by the wider community. 

If you have any questions or need me to make changes, please let me know! 

### What is the purpose of this pull request?

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [X] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
