### PR TITLE
feat: export config types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-variants",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "🦄 Tailwindcss first-class variant API",
   "keywords": [
     "tailwindcss",

--- a/src/config.d.ts
+++ b/src/config.d.ts
@@ -3,6 +3,8 @@ import type {extendTailwindMerge} from "tailwind-merge";
 type MergeConfig = Parameters<typeof extendTailwindMerge>[0];
 type LegacyMergeConfig = Extract<MergeConfig, {extend?: unknown}>["extend"];
 
+export type TWMergeConfig = MergeConfig & LegacyMergeConfig;
+
 export type TWMConfig = {
   /**
    * Whether to merge the class names with `tailwind-merge` library.
@@ -15,7 +17,7 @@ export type TWMConfig = {
    * The config object for `tailwind-merge` library.
    * @see https://github.com/dcastil/tailwind-merge/blob/v2.2.0/docs/configuration.md
    */
-  twMergeConfig?: MergeConfig & LegacyMergeConfig;
+  twMergeConfig?: TWMergeConfig;
 };
 
 export type TVConfig = TWMConfig;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,8 +1,9 @@
-import {TVConfig, TWMConfig} from "./config";
+import {TVConfig, TWMConfig, TWMergeConfig} from "./config";
 import {CnOptions, CnReturn, TV} from "./types";
 
 export * from "./types";
 
+// util function
 export declare const cnBase: <T extends CnOptions>(...classes: T) => CnReturn;
 
 export declare const cn: <T extends CnOptions>(...classes: T) => (config?: TWMConfig) => CnReturn;
@@ -11,3 +12,6 @@ export declare const cn: <T extends CnOptions>(...classes: T) => (config?: TWMCo
 export declare const tv: TV;
 
 export declare function createTV(config: TVConfig): TV;
+
+// types
+export type {TVConfig, TWMConfig, TWMergeConfig};

--- a/src/lite.d.ts
+++ b/src/lite.d.ts
@@ -2,6 +2,7 @@ import {CnOptions, CnReturn, TVLite} from "./types";
 
 export * from "./types";
 
+// util function
 export declare const cnBase: <T extends CnOptions>(...classes: T) => CnReturn;
 
 export declare const cn: <T extends CnOptions>(...classes: T) => CnReturn;


### PR DESCRIPTION
Resolves https://github.com/heroui-inc/tailwind-variants/issues/266

### Problem
The core `TVConfig` type was not exported in the package build, which made it impossible for downstream projects to extend or reuse it directly. This limited flexibility and type-safety for user who wanted to build on top of `tailwind-variants`.

### Solution
Exported the `config.d.ts` types from the public API, allowing downstream projects to safely import and extend it as needed.

### Breaking Changes
No.

### Version
Bump version from `3.0.0` to `3.1.0`.

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
