### PR TITLE
fix: use 'type' for type-only imports and specify file extensions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,7 @@
-import {TVConfig, TWMConfig, TWMergeConfig} from "./config";
-import {CnOptions, CnReturn, TV} from "./types";
+import type {TVConfig, TWMConfig, TWMergeConfig} from "./config.d.ts";
+import type {CnOptions, CnReturn, TV} from "./types.d.ts";
 
-export * from "./types";
+export type * from "./types.d.ts";
 
 // util function
 export declare const cnBase: <T extends CnOptions>(...classes: T) => CnReturn;

--- a/src/lite.d.ts
+++ b/src/lite.d.ts
@@ -1,6 +1,6 @@
-import {CnOptions, CnReturn, TVLite} from "./types";
+import type {CnOptions, CnReturn, TVLite} from "./types.d.ts";
 
-export * from "./types";
+export type * from "./types.d.ts";
 
 // util function
 export declare const cnBase: <T extends CnOptions>(...classes: T) => CnReturn;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,6 +1,5 @@
 import type {ClassNameValue as ClassValue} from "tailwind-merge";
-
-import {TVConfig} from "./config";
+import type {TVConfig} from "./config.d.ts";
 
 /**
  * ----------------------------------------

--- a/src/utils.d.ts
+++ b/src/utils.d.ts
@@ -1,5 +1,5 @@
-import {TWMConfig} from "./config";
-import {CnOptions, CnReturn} from "./types";
+import type {TWMConfig} from "./config.d.ts";
+import type {CnOptions, CnReturn} from "./types.d.ts";
 
 export declare const falsyToString: <T>(value: T) => T | string;
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

close #271

### Additional context

before https://arethetypeswrong.github.io/?p=tailwind-variants%403.1.0:
<img width="2368" height="450" alt="Image" src="https://github.com/user-attachments/assets/275a12df-70ba-4bd4-b94b-dfbd45edf613" />

after:
<img width="2304" height="414" alt="image" src="https://github.com/user-attachments/assets/c51cee1c-6da8-4a87-83ec-6ae341e23272" />

all "internal resolution error" errors are gone.

---

### What is the purpose of this pull request?

- [x] Bug fix

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [ ] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
