### PR TITLE
feat(core): add variant-level slot caching

### DIFF
--- a/src/__tests__/tv-cache.test.ts
+++ b/src/__tests__/tv-cache.test.ts
@@ -1,0 +1,313 @@
+import {expect, describe, test} from "@jest/globals";
+
+import {tv} from "../index";
+
+describe("Tailwind Variants (TV) - Slot Caching", () => {
+  test("should return cached strings for repeated calls with same variant props", () => {
+    const menu = tv({
+      base: "base-class",
+      slots: {
+        title: "title-class",
+        item: "item-class",
+      },
+      variants: {
+        color: {
+          primary: {
+            title: "title--primary",
+            item: "item--primary",
+          },
+          secondary: {
+            title: "title--secondary",
+            item: "item--secondary",
+          },
+        },
+      },
+    });
+
+    const result1 = menu({color: "primary"});
+    const result2 = menu({color: "primary"});
+
+    // Slot functions should return identical strings (reference equality)
+    expect(result1.base()).toBe(result2.base());
+    expect(result1.title()).toBe(result2.title());
+    expect(result1.item()).toBe(result2.item());
+  });
+
+  test("should return different strings for different variant props", () => {
+    const menu = tv({
+      base: "base-class",
+      slots: {
+        title: "title-class",
+      },
+      variants: {
+        color: {
+          primary: {title: "title--primary"},
+          secondary: {title: "title--secondary"},
+        },
+      },
+    });
+
+    const primary = menu({color: "primary"});
+    const secondary = menu({color: "secondary"});
+
+    expect(primary.title()).not.toBe(secondary.title());
+    expect(primary.title()).toBe("title-class title--primary");
+    expect(secondary.title()).toBe("title-class title--secondary");
+  });
+
+  test("should bypass cache when slot-level overrides are provided", () => {
+    const menu = tv({
+      base: "base-class",
+      slots: {
+        title: "text-sm",
+      },
+      variants: {
+        color: {
+          primary: {title: "text-blue-500"},
+        },
+      },
+    });
+
+    const result = menu({color: "primary"});
+
+    // No override — uses cached string
+    const noOverride = result.title();
+
+    // With className override — bypasses cache, runs tw-merge
+    const withOverride = result.title({className: "text-red-500"});
+
+    expect(noOverride).toBe("text-sm text-blue-500");
+    expect(withOverride).toBe("text-sm text-red-500");
+  });
+
+  test("should bypass cache when slot-level variant overrides are provided", () => {
+    const menu = tv({
+      base: "base-class",
+      slots: {
+        title: "title-class",
+      },
+      variants: {
+        color: {
+          primary: {title: "title--primary"},
+          secondary: {title: "title--secondary"},
+        },
+      },
+    });
+
+    const result = menu({color: "primary"});
+
+    // No override — cached
+    expect(result.title()).toBe("title-class title--primary");
+
+    // Slot-level variant override — bypasses cache
+    expect(result.title({color: "secondary"})).toBe("title-class title--secondary");
+  });
+
+  test("should cache correctly with compoundVariants", () => {
+    const button = tv({
+      base: "base-class",
+      slots: {
+        label: "label-class",
+      },
+      variants: {
+        variant: {
+          solid: {label: "label--solid"},
+          outline: {label: "label--outline"},
+        },
+        color: {
+          primary: {label: "label--primary"},
+          danger: {label: "label--danger"},
+        },
+      },
+      compoundVariants: [
+        {
+          variant: "solid",
+          color: "danger",
+          class: {label: "label--solid-danger"},
+        },
+      ],
+    });
+
+    const result1 = button({variant: "solid", color: "danger"});
+    const result2 = button({variant: "solid", color: "danger"});
+
+    // Compound variant classes should be included
+    expect(result1.label()).toContain("label--solid-danger");
+
+    // Should be cached (reference equality)
+    expect(result1.label()).toBe(result2.label());
+
+    // Different variant combo should not include compound classes
+    const result3 = button({variant: "outline", color: "danger"});
+
+    expect(result3.label()).not.toContain("label--solid-danger");
+  });
+
+  test("should cache correctly with defaultVariants", () => {
+    const menu = tv({
+      base: "base-class",
+      slots: {
+        title: "title-class",
+      },
+      variants: {
+        color: {
+          primary: {title: "title--primary"},
+          secondary: {title: "title--secondary"},
+        },
+      },
+      defaultVariants: {
+        color: "primary",
+      },
+    });
+
+    // No args — uses default variant
+    const withDefault = menu();
+    // Explicit same value as default
+    const withExplicit = menu({color: "primary"});
+
+    expect(withDefault.title()).toBe("title-class title--primary");
+    expect(withExplicit.title()).toBe("title-class title--primary");
+  });
+
+  test("should cache correctly with extend", () => {
+    const baseMenu = tv({
+      base: "base-class",
+      slots: {
+        title: "title-class",
+      },
+      variants: {
+        size: {
+          sm: {title: "title--sm"},
+          md: {title: "title--md"},
+        },
+      },
+    });
+
+    const extendedMenu = tv({
+      extend: baseMenu,
+      variants: {
+        color: {
+          primary: {title: "title--primary"},
+        },
+      },
+    });
+
+    const result1 = extendedMenu({size: "sm", color: "primary"});
+    const result2 = extendedMenu({size: "sm", color: "primary"});
+
+    // Should include both parent and child variant classes
+    expect(result1.title()).toContain("title--sm");
+    expect(result1.title()).toContain("title--primary");
+
+    // Should be cached
+    expect(result1.title()).toBe(result2.title());
+  });
+
+  test("should not affect non-slot components", () => {
+    const badge = tv({
+      base: "badge-base",
+      variants: {
+        color: {
+          primary: "badge--primary",
+          secondary: "badge--secondary",
+        },
+      },
+    });
+
+    // Non-slot components return strings directly, no caching needed
+    expect(badge({color: "primary"})).toBe("badge-base badge--primary");
+    expect(badge({color: "secondary"})).toBe("badge-base badge--secondary");
+  });
+
+  test("should cache correctly with boolean variants", () => {
+    const button = tv({
+      base: "base-class",
+      slots: {
+        label: "label-class",
+      },
+      variants: {
+        disabled: {
+          true: {label: "label--disabled"},
+        },
+      },
+    });
+
+    const result1 = button({disabled: true});
+    const result2 = button({disabled: true});
+
+    expect(result1.label()).toContain("label--disabled");
+    expect(result1.label()).toBe(result2.label());
+
+    // false should produce different result
+    const result3 = button({disabled: false});
+
+    expect(result3.label()).not.toContain("label--disabled");
+  });
+
+  test("should isolate caches between different tv definitions", () => {
+    const menu1 = tv({
+      base: "menu1-base",
+      slots: {
+        title: "menu1-title",
+      },
+      variants: {
+        color: {
+          primary: {title: "menu1--primary"},
+        },
+      },
+    });
+
+    const menu2 = tv({
+      base: "menu2-base",
+      slots: {
+        title: "menu2-title",
+      },
+      variants: {
+        color: {
+          primary: {title: "menu2--primary"},
+        },
+      },
+    });
+
+    const r1 = menu1({color: "primary"});
+    const r2 = menu2({color: "primary"});
+
+    // Each tv() definition has its own cache
+    expect(r1.title()).toBe("menu1-title menu1--primary");
+    expect(r2.title()).toBe("menu2-title menu2--primary");
+  });
+
+  test("should cache correctly with compoundSlots", () => {
+    const button = tv({
+      base: "base-class",
+      slots: {
+        label: "label-class",
+        icon: "icon-class",
+      },
+      variants: {
+        size: {
+          sm: {label: "label--sm", icon: "icon--sm"},
+          md: {label: "label--md", icon: "icon--md"},
+        },
+      },
+      compoundSlots: [
+        {
+          slots: ["label", "icon"],
+          size: "sm",
+          class: "compound-sm",
+        },
+      ],
+    });
+
+    const result1 = button({size: "sm"});
+    const result2 = button({size: "sm"});
+
+    // Compound slot classes should be included
+    expect(result1.label()).toContain("compound-sm");
+    expect(result1.icon()).toContain("compound-sm");
+
+    // Should be cached
+    expect(result1.label()).toBe(result2.label());
+    expect(result1.icon()).toBe(result2.icon());
+  });
+});

--- a/src/core.js
+++ b/src/core.js
@@ -64,6 +64,67 @@ export const getTailwindVariants = (cn) => {
       ? compoundVariantsProps
       : flatMergeArrays(extend?.compoundVariants, compoundVariantsProps);
 
+    const hasSlots = !isEmptyObject(slotProps) || !isExtendedSlotsEmpty;
+
+    // Variant-level slot caching: shared across all component() calls with the same variant combo.
+    // Layer 1 (variantCache): variant key → slot closures (skips inner function creation + variant resolution)
+    // Layer 2 (stringCache): variant key → resolved class strings (skips tw-merge entirely)
+    const variantCache = hasSlots ? new Map() : null;
+    const stringCache = hasSlots ? new Map() : null;
+
+    // Collect all prop keys that affect slot output: variant keys + compound variant/slot condition keys.
+    // Computed once at definition time, not per call.
+    const cacheRelevantKeys = hasSlots
+      ? (() => {
+          const keys = Object.keys(variants);
+
+          for (let i = 0; i < compoundVariants.length; i++) {
+            for (const key in compoundVariants[i]) {
+              if (key !== "class" && key !== "className" && !keys.includes(key)) {
+                keys.push(key);
+              }
+            }
+          }
+
+          for (let i = 0; i < compoundSlots.length; i++) {
+            for (const key in compoundSlots[i]) {
+              if (
+                key !== "slots" &&
+                key !== "class" &&
+                key !== "className" &&
+                !keys.includes(key)
+              ) {
+                keys.push(key);
+              }
+            }
+          }
+
+          return keys;
+        })()
+      : null;
+
+    const serializeVariantProps = hasSlots
+      ? (props) => {
+          if (!props) return "";
+
+          let key = "";
+
+          for (let i = 0; i < cacheRelevantKeys.length; i++) {
+            const value = props[cacheRelevantKeys[i]];
+
+            if (value !== undefined) {
+              if (typeof value === "object" && value !== null) {
+                key += cacheRelevantKeys[i] + ":" + JSON.stringify(value) + "|";
+              } else {
+                key += cacheRelevantKeys[i] + ":" + String(value) + "|";
+              }
+            }
+          }
+
+          return key;
+        }
+      : null;
+
     const component = (props) => {
       if (isEmptyObject(variants) && isEmptyObject(slotProps) && isExtendedSlotsEmpty) {
         return cn(base, props?.class, props?.className)(config);
@@ -79,6 +140,38 @@ export const getTailwindVariants = (cn) => {
         throw new TypeError(
           `The "compoundSlots" prop must be an array. Received: ${typeof compoundSlots}`,
         );
+      }
+
+      // Slot cache: check for hit before creating inner functions
+      let cacheKey;
+
+      if (hasSlots) {
+        cacheKey = serializeVariantProps(props);
+
+        const cachedClosures = variantCache.get(cacheKey);
+
+        if (cachedClosures) {
+          let cachedStrings = stringCache.get(cacheKey);
+
+          if (!cachedStrings) {
+            cachedStrings = {};
+
+            for (const slotKey in cachedClosures) {
+              cachedStrings[slotKey] = cachedClosures[slotKey]();
+            }
+
+            stringCache.set(cacheKey, cachedStrings);
+          }
+
+          const slotsFns = {};
+
+          for (const slotKey in cachedClosures) {
+            slotsFns[slotKey] = (slotProps) =>
+              slotProps != null ? cachedClosures[slotKey](slotProps) : cachedStrings[slotKey];
+          }
+
+          return slotsFns;
+        }
       }
 
       const getVariantValue = (variant, vrs = variants, _slotKey = null, slotProps = null) => {
@@ -275,8 +368,8 @@ export const getTailwindVariants = (cn) => {
         return result;
       };
 
-      // with slots
-      if (!isEmptyObject(slotProps) || !isExtendedSlotsEmpty) {
+      // with slots (cache miss path — closures are computed and cached)
+      if (hasSlots) {
         const slotsFns = {};
 
         if (typeof slots === "object" && !isEmptyObject(slots)) {
@@ -299,7 +392,26 @@ export const getTailwindVariants = (cn) => {
           }
         }
 
-        return slotsFns;
+        // Cache closures and their resolved strings for this variant combo
+        variantCache.set(cacheKey, slotsFns);
+
+        const cachedStrings = {};
+
+        for (const slotKey in slotsFns) {
+          cachedStrings[slotKey] = slotsFns[slotKey]();
+        }
+
+        stringCache.set(cacheKey, cachedStrings);
+
+        // Return with string cache support: no-arg calls skip tw-merge
+        const result = {};
+
+        for (const slotKey in slotsFns) {
+          result[slotKey] = (slotProps) =>
+            slotProps != null ? slotsFns[slotKey](slotProps) : cachedStrings[slotKey];
+        }
+
+        return result;
       }
 
       // normal variants


### PR DESCRIPTION
## Summary

Add a two-layer Map-based cache per `tv()` definition that eliminates redundant `tailwind-merge` calls for slot-based components. Cache hit skips all inner function creation and variant resolution — returning cached class strings directly.

Closes #292

## How it works

**Layer 1 (variant cache):** serialized variant props → slot closure functions. On cache hit, the early return fires *before* `getVariantValue`, `getCompoundVariantsValue`, and other inner functions are created.

**Layer 2 (string cache):** same key → resolved class strings. No-arg slot calls (the common case) return cached strings without running `tailwind-merge`.

Slot calls with `className`/`class` overrides or slot-level variant overrides bypass the string cache and delegate to the cached closures — preserving full `tailwind-merge` behavior for per-call customization.

Non-slot components are completely unaffected (no caching overhead added).

### Cache key

Built from all prop keys that affect slot output: variant keys + compound variant/slot condition keys. Computed once at `tv()` definition time. `class`, `className`, and other irrelevant props are excluded.

## Benchmark results

> **[Live demo on StackBlitz](https://stackblitz.com/github/YevheniiKotyrlo/tv-caching-benchmark)** — runs the before/after benchmark in-browser
>
> **[Full source + 182 tests + 15 bench suites](https://github.com/YevheniiKotyrlo/tv-caching-benchmark)**

| Scenario | Uncached | Cached | Speedup |
|---|---|---|---|
| Complex component (3 slots, 34 compounds) | 67K ops/s | 2.30M ops/s | **34.5x** |
| 15-button dashboard | 4.1K ops/s | 156K ops/s | **37.8x** |
| className override path | 61K ops/s | 89K ops/s | **1.46x** |
| Cold call (first, includes Map.set) | 348K ops/s | 306K ops/s | **1.14x slower** |
| Lifecycle (1 cold + 9 warm) | 37K ops/s | 165K ops/s | **4.50x** |

Tested with React Compiler (`babel-plugin-react-compiler@1.0.0`) ON — [6 dedicated tests](https://github.com/YevheniiKotyrlo/tv-caching-benchmark/blob/main/src/react-compiler.test.tsx) prove that per-instance memoization (`useMemoCache`) cannot replace cross-instance caching.

## Changes

- `src/core.js`: ~115 lines added inside `getTailwindVariants` — cache Maps, key serialization, early return on hit, cache population on miss
- `src/__tests__/tv-cache.test.ts`: 11 tests covering cache hits, cache bypass, compound variants, compound slots, extend, boolean variants, isolation between definitions

## Quality gates

| Gate | Result |
|---|---|
| Existing tests (169) | all pass |
| New caching tests (11) | all pass |
| TypeScript | clean |
| Lint | clean |
| Build | clean |
