### PR TITLE
fix(tw-merge): ensure config passed to cnMerge gets used

### DIFF
--- a/src/tw-merge.js
+++ b/src/tw-merge.js
@@ -23,6 +23,15 @@ const executeMerge = (classnames, config) => {
 
   if (!base || !(config?.twMerge ?? true)) return base;
 
+  // save twMergeConfig to the cache
+  if (
+    !isEmptyObject(config.twMergeConfig) &&
+    !isEqual(config.twMergeConfig, state.cachedTwMergeConfig)
+  ) {
+    state.didTwMergeConfigChange = true;
+    state.cachedTwMergeConfig = config.twMergeConfig;
+  }
+
   if (!state.cachedTwMerge || state.didTwMergeConfigChange) {
     state.didTwMergeConfigChange = false;
 


### PR DESCRIPTION
### Description

Presently, `cnMerge`'s accuracy mostly depends on `tv` (or any of it's variation) being called first, since the config passed to it is never used or synced to `state`, this means custom configs passed down to `cnMerge` are discarded and hence the output contains conflicting classes.

This fix basically applies the config reconciliation logic being used within `tv`.

Might be related to #294 

### Additional context


---

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/jrgarciadev/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
