### PR TITLE
fix: slots shared-state contamination

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/__tests__/tv-slots-independence.test.ts
+++ b/src/__tests__/tv-slots-independence.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, test} from "vitest";
 
-import {tv} from "../index";
-import {tv as tvLite} from "../lite";
+import {createTV, tv} from "../index";
+import {createTV as createTVLite, tv as tvLite} from "../lite";
 
 const slotsConfig = {
   slots: {
@@ -10,18 +10,58 @@ const slotsConfig = {
   },
   variants: {
     size: {
-      sm: {root: "root-sm"},
-      lg: {root: "root-lg"},
+      sm: {root: "root-sm", icon: "icon-sm"},
+      lg: {root: "root-lg", icon: "icon-lg"},
     },
   },
   defaultVariants: {size: "sm" as const},
 };
 
-describe.each([
+/**
+ * HeroUI Chip / React pattern (no React runtime):
+ *   const slots = useMemo(() => chip({...}), [deps]);
+ *   slots.base({ className }) // every render
+ */
+const chipConfig = {
+  slots: {
+    base: "chip",
+    label: "chip__label",
+  },
+  variants: {
+    color: {
+      warning: {base: "chip--warning"},
+      success: {base: "chip--success"},
+      default: {base: "chip--default"},
+    },
+    size: {
+      sm: {base: "chip--sm"},
+      md: {base: "chip--md"},
+    },
+    variant: {
+      soft: {base: "chip--soft"},
+      primary: {base: "chip--primary"},
+    },
+  },
+  defaultVariants: {
+    color: "default" as const,
+    size: "md" as const,
+    variant: "soft" as const,
+  },
+};
+
+const warningSoft = ["chip", "chip--warning", "chip--sm", "chip--soft"] as const;
+const successPrimary = ["chip", "chip--success", "chip--sm", "chip--primary"] as const;
+
+const runtimes = [
   ["tv", tv],
   ["tv/lite", tvLite],
-] as const)("%s slots independence (#304)", (_label, createTv) => {
-  test("keeps interleaved parent calls independent", () => {
+  ["createTV", createTV({})],
+  ["createTV/lite", createTVLite()],
+] as const;
+
+describe.each(runtimes)("%s slots independence (#304)", (_label, createTv) => {
+  // ryuji — https://github.com/heroui-inc/tailwind-variants/issues/304
+  test("ryuji: interleaved calls keep independent results and identity", () => {
     const v = createTv(slotsConfig);
 
     const s1 = v({size: "sm"});
@@ -32,24 +72,48 @@ describe.each([
     expect(s1.root()).not.toHaveClass(["root-lg"]);
     expect(s2.root()).toHaveClass(["root-base", "root-lg"]);
     expect(s2.root()).not.toHaveClass(["root-sm"]);
-  });
 
-  test("does not contaminate a held result after a later call", () => {
-    const v = createTv(slotsConfig);
+    // Held / cold-path result must not pick up later props (incl. multi-slot).
+    expect(s1.icon()).toHaveClass(["icon-base", "icon-sm"]);
+    expect(s1.icon()).not.toHaveClass(["icon-lg"]);
 
-    const held = v({size: "sm"});
+    const viaDefault = v();
 
     v({size: "lg"});
-
-    expect(held.root()).toHaveClass(["root-base", "root-sm"]);
-    expect(held.root()).not.toHaveClass(["root-lg"]);
+    expect(viaDefault.root()).toHaveClass(["root-base", "root-sm"]);
+    expect(viaDefault.root()).not.toHaveClass(["root-lg"]);
   });
 
-  test("reuses the same result object for the same props fingerprint", () => {
+  // lightsound — issue comment (HeroUI Chip + useMemo + className every render)
+  test("lightsound: held slots survive sibling mounts when re-applying className", () => {
+    const chip = createTv(chipConfig);
+
+    const slotsA = chip({color: "warning", size: "sm", variant: "soft"});
+
+    expect(slotsA.base({className: "badge"})).toHaveClass([...warningSoft, "badge"]);
+
+    const slotsB = chip({color: "success", size: "sm", variant: "primary"});
+
+    expect(slotsB.base({className: "other"})).toHaveClass([...successPrimary, "other"]);
+
+    // A re-renders without useMemo recompute
+    expect(slotsA.base({className: "badge"})).toHaveClass([...warningSoft, "badge"]);
+    expect(slotsA.base({className: "badge"})).not.toHaveClass([
+      "chip--success",
+      "chip--primary",
+      "chip--default",
+    ]);
+
+    chip({color: "default", size: "sm", variant: "soft"});
+
+    expect(slotsA.base({className: "badge"})).toHaveClass([...warningSoft, "badge"]);
+    expect(slotsA.label({className: "badge-label"})).toHaveClass(["chip__label", "badge-label"]);
+  });
+
+  test("reuses the same result object for the same props after cold invoke", () => {
     const v = createTv(slotsConfig);
 
-    // First parent invoke is a cold path (no cache); warm reuse starts afterward.
-    v({size: "sm"});
+    v({size: "sm"}); // cold path (uncached)
 
     const a = v({size: "sm"});
     const b = v({size: "sm"});
@@ -58,17 +122,64 @@ describe.each([
     expect(a.root()).toHaveClass(["root-base", "root-sm"]);
   });
 
-  test("slot class overrides do not poison sibling instances", () => {
+  test("class and slot-level variant overrides do not poison siblings", () => {
     const v = createTv(slotsConfig);
-
     const s1 = v({size: "sm"});
     const s2 = v({size: "lg"});
 
     expect(s1.root({class: "extra"})).toHaveClass(["root-base", "root-sm", "extra"]);
+    expect(s1.root({size: "lg"})).toHaveClass(["root-base", "root-lg"]);
+    expect(s1.root({size: "lg"})).not.toHaveClass(["root-sm"]);
+
     expect(s2.root()).toHaveClass(["root-base", "root-lg"]);
-    expect(s2.root()).not.toHaveClass(["extra"]);
+    expect(s2.root()).not.toHaveClass(["extra", "root-sm"]);
     expect(s1.root()).toHaveClass(["root-base", "root-sm"]);
-    expect(s1.root()).not.toHaveClass(["extra"]);
+    expect(s1.icon({size: "lg"})).toHaveClass(["icon-base", "icon-lg"]);
+    expect(s2.icon()).toHaveClass(["icon-base", "icon-lg"]);
+  });
+
+  test("keeps results independent when props fingerprint cannot be built", () => {
+    const v = createTv({
+      slots: {root: "root-base"},
+      variants: {
+        size: {
+          sm: {root: "root-sm"},
+          lg: {root: "root-lg"},
+        },
+      },
+      defaultVariants: {size: "sm"},
+    });
+
+    const circular: {self?: unknown; size: "sm" | "lg"} = {size: "sm"};
+
+    circular.self = circular;
+
+    const held = v(circular as {size: "sm"});
+
+    v({size: "lg"});
+
+    expect(held.root()).toHaveClass(["root-base", "root-sm"]);
+    expect(held.root()).not.toHaveClass(["root-lg"]);
+  });
+
+  test("extended slots components keep held results independent", () => {
+    const base = createTv(slotsConfig);
+    const extended = createTv({
+      extend: base,
+      variants: {
+        size: {
+          sm: {root: "root-sm-ext"},
+          lg: {root: "root-lg-ext"},
+        },
+      },
+    });
+
+    const held = extended({size: "sm"});
+
+    extended({size: "lg"});
+
+    expect(held.root()).toHaveClass(["root-base", "root-sm", "root-sm-ext"]);
+    expect(held.root()).not.toHaveClass(["root-lg", "root-lg-ext"]);
   });
 
   test("keeps compoundVariants independent across interleaved calls", () => {

--- a/src/__tests__/tv-slots-independence.test.ts
+++ b/src/__tests__/tv-slots-independence.test.ts
@@ -1,0 +1,201 @@
+import {describe, expect, test} from "vitest";
+
+import {tv} from "../index";
+import {tv as tvLite} from "../lite";
+
+const slotsConfig = {
+  slots: {
+    root: "root-base",
+    icon: "icon-base",
+  },
+  variants: {
+    size: {
+      sm: {root: "root-sm"},
+      lg: {root: "root-lg"},
+    },
+  },
+  defaultVariants: {size: "sm" as const},
+};
+
+describe.each([
+  ["tv", tv],
+  ["tv/lite", tvLite],
+] as const)("%s slots independence (#304)", (_label, createTv) => {
+  test("keeps interleaved parent calls independent", () => {
+    const v = createTv(slotsConfig);
+
+    const s1 = v({size: "sm"});
+    const s2 = v({size: "lg"});
+
+    expect(s1).not.toBe(s2);
+    expect(s1.root()).toHaveClass(["root-base", "root-sm"]);
+    expect(s1.root()).not.toHaveClass(["root-lg"]);
+    expect(s2.root()).toHaveClass(["root-base", "root-lg"]);
+    expect(s2.root()).not.toHaveClass(["root-sm"]);
+  });
+
+  test("does not contaminate a held result after a later call", () => {
+    const v = createTv(slotsConfig);
+
+    const held = v({size: "sm"});
+
+    v({size: "lg"});
+
+    expect(held.root()).toHaveClass(["root-base", "root-sm"]);
+    expect(held.root()).not.toHaveClass(["root-lg"]);
+  });
+
+  test("reuses the same result object for the same props fingerprint", () => {
+    const v = createTv(slotsConfig);
+
+    const a = v({size: "sm"});
+    const b = v({size: "sm"});
+
+    expect(a).toBe(b);
+    expect(a.root()).toHaveClass(["root-base", "root-sm"]);
+  });
+
+  test("slot class overrides do not poison sibling instances", () => {
+    const v = createTv(slotsConfig);
+
+    const s1 = v({size: "sm"});
+    const s2 = v({size: "lg"});
+
+    expect(s1.root({class: "extra"})).toHaveClass(["root-base", "root-sm", "extra"]);
+    expect(s2.root()).toHaveClass(["root-base", "root-lg"]);
+    expect(s2.root()).not.toHaveClass(["extra"]);
+    expect(s1.root()).toHaveClass(["root-base", "root-sm"]);
+    expect(s1.root()).not.toHaveClass(["extra"]);
+  });
+
+  test("keeps compoundVariants independent across interleaved calls", () => {
+    const v = createTv({
+      slots: {
+        root: "root-base",
+        label: "label-base",
+      },
+      variants: {
+        color: {
+          primary: {root: "root-primary"},
+          danger: {root: "root-danger"},
+        },
+        solid: {
+          true: {label: "label-solid"},
+          false: {label: "label-soft"},
+        },
+      },
+      compoundVariants: [
+        {
+          color: "danger",
+          solid: true,
+          class: {label: "label-danger-solid"},
+        },
+      ],
+      defaultVariants: {
+        color: "primary",
+        solid: false,
+      },
+    });
+
+    const soft = v({color: "primary", solid: false});
+    const danger = v({color: "danger", solid: true});
+
+    expect(soft).not.toBe(danger);
+    expect(soft.label()).toHaveClass(["label-base", "label-soft"]);
+    expect(soft.label()).not.toHaveClass(["label-danger-solid"]);
+    expect(danger.label()).toHaveClass(["label-base", "label-solid", "label-danger-solid"]);
+    expect(soft.label()).toHaveClass(["label-base", "label-soft"]);
+  });
+
+  test("keeps compoundSlots independent across interleaved calls", () => {
+    const v = createTv({
+      slots: {
+        title: "title-base",
+        subtitle: "subtitle-base",
+      },
+      variants: {
+        color: {
+          primary: {},
+          secondary: {},
+        },
+      },
+      compoundSlots: [
+        {
+          slots: ["title", "subtitle"],
+          color: "secondary",
+          class: "truncate",
+        },
+      ],
+      defaultVariants: {
+        color: "primary",
+      },
+    });
+
+    const primary = v({color: "primary"});
+    const secondary = v({color: "secondary"});
+
+    expect(primary).not.toBe(secondary);
+    expect(primary.title()).toHaveClass(["title-base"]);
+    expect(primary.title()).not.toHaveClass(["truncate"]);
+    expect(secondary.title()).toHaveClass(["title-base", "truncate"]);
+    expect(primary.title()).not.toHaveClass(["truncate"]);
+  });
+
+  test("invalidates parent cache after in-place compoundVariants mutation", () => {
+    const menu = createTv({
+      slots: {
+        root: "root",
+        title: "title",
+      },
+      variants: {
+        color: {
+          primary: {root: "root-p", title: "title-p"},
+          secondary: {root: "root-s", title: "title-s"},
+        },
+      },
+      compoundVariants: [{color: "primary", class: {title: "compound-old"}}],
+      defaultVariants: {color: "primary"},
+    });
+
+    expect(menu({color: "primary"}).title()).toHaveClass(["title", "title-p", "compound-old"]);
+
+    menu.compoundVariants[0].color = "secondary";
+    menu.compoundVariants[0].class = {title: "compound-new"};
+
+    expect(menu({color: "primary"}).title()).toHaveClass(["title", "title-p"]);
+    expect(menu({color: "primary"}).title()).not.toHaveClass(["compound-old", "compound-new"]);
+    expect(menu({color: "secondary"}).title()).toHaveClass(["title", "title-s", "compound-new"]);
+  });
+
+  test("invalidates parent cache after in-place compoundSlots mutation", () => {
+    const menu = createTv({
+      slots: {
+        title: "title-base",
+        subtitle: "subtitle-base",
+      },
+      variants: {
+        color: {
+          primary: {},
+          secondary: {},
+        },
+      },
+      compoundSlots: [
+        {
+          slots: ["title", "subtitle"],
+          color: "secondary",
+          class: "truncate",
+        },
+      ],
+      defaultVariants: {
+        color: "secondary",
+      },
+    });
+
+    expect(menu().title()).toHaveClass(["title-base", "truncate"]);
+
+    menu.compoundSlots[0].class = "line-clamp-2";
+
+    expect(menu().title()).toHaveClass(["title-base", "line-clamp-2"]);
+    expect(menu().title()).not.toHaveClass(["truncate"]);
+  });
+});

--- a/src/__tests__/tv-slots-independence.test.ts
+++ b/src/__tests__/tv-slots-independence.test.ts
@@ -48,6 +48,9 @@ describe.each([
   test("reuses the same result object for the same props fingerprint", () => {
     const v = createTv(slotsConfig);
 
+    // First parent invoke is a cold path (no cache); warm reuse starts afterward.
+    v({size: "sm"});
+
     const a = v({size: "sm"});
     const b = v({size: "sm"});
 

--- a/src/internal/cache.ts
+++ b/src/internal/cache.ts
@@ -202,35 +202,50 @@ export const buildCompoundsSignature = (
   return signature;
 };
 
-/** Two-generation bounded Map cache. */
-export const createResultCache = (limit = VARIANT_CACHE_LIMIT): ResultCache => {
-  let primary: Map<string, CacheValue> = new Map();
-  let secondary: Map<string, CacheValue> | null = null;
+type BoundedCache<T> = {
+  get(key: string): T | CacheMiss;
+  set(key: string, value: T): void;
+};
+
+/** Two-generation bounded Map cache for arbitrary values. */
+export const createBoundedCache = <T>(limit = VARIANT_CACHE_LIMIT): BoundedCache<T> => {
+  let primary: Map<string, T> = new Map();
+  let secondary: Map<string, T> | null = null;
 
   return {
-    get(key: string): CacheLookup {
-      let value = primary.get(key);
+    get(key: string): T | CacheMiss {
+      if (primary.has(key)) return primary.get(key) as T;
 
-      if (value !== undefined || primary.has(key)) return value;
+      if (secondary?.has(key)) {
+        const value = secondary.get(key) as T;
 
-      if (secondary) {
-        value = secondary.get(key);
+        primary.set(key, value);
 
-        if (value !== undefined || secondary.has(key)) {
-          primary.set(key, value);
-
-          return value;
-        }
+        return value;
       }
 
       return CACHE_MISS;
     },
-    set(key: string, value: CacheValue) {
+    set(key: string, value: T) {
       if (primary.size >= limit) {
         secondary = primary;
         primary = new Map();
       }
       primary.set(key, value);
+    },
+  };
+};
+
+/** Two-generation bounded Map cache. */
+export const createResultCache = (limit = VARIANT_CACHE_LIMIT): ResultCache => {
+  const cache = createBoundedCache<CacheValue>(limit);
+
+  return {
+    get(key: string): CacheLookup {
+      return cache.get(key);
+    },
+    set(key: string, value: CacheValue) {
+      cache.set(key, value);
     },
   };
 };

--- a/src/internal/class-resolver.ts
+++ b/src/internal/class-resolver.ts
@@ -3,6 +3,7 @@ import {
   buildCompoundsSignature,
   buildPropsFingerprint,
   CACHE_MISS,
+  createBoundedCache,
   createLazyOverrideMerge,
   createResultCache,
   type ResultCache,
@@ -300,120 +301,139 @@ const createVariantResolver = (resolved: ResolvedOptions, cn: CnAdapter): Runtim
   }) as RuntimeComponent;
 };
 
+type SlotsResult = Record<string, (slotProps?: AnyRecord) => string | undefined>;
+
 const createSlotsResolver = (resolved: ResolvedOptions, cn: CnAdapter): RuntimeComponent => {
   const {config, defaultVariants, deferredError, slots, variantKeys} = resolved;
-  let currentProps: AnyRecord | undefined;
-  let currentCompoundsSig = "";
-  let useResultCache = false;
-  let coldParentInvokesRemaining = 1;
-  let slotsFns: Record<string, (slotProps?: AnyRecord) => string | undefined> | null = null;
+
+  let variants: CompiledVariant[] | null = null;
+  let compoundVariants: CompiledCompoundVariant[] | null = null;
+  let compoundSlots: CompiledCompoundSlot[] | null = null;
+  let compoundSlotsBySlot: Record<string, CompiledCompoundSlot[]> | null = null;
+  let keys: string[] | null = null;
+  let hasCompounds = false;
+  let mergeOverride: ReturnType<typeof createLazyOverrideMerge> | null = null;
+  let parentCache: ReturnType<typeof createBoundedCache<SlotsResult>> | null = null;
+
+  const ensureCompiled = () => {
+    if (keys !== null) return;
+
+    if (
+      resolved.compiledVariants === null ||
+      resolved.compiledCompoundVariants === null ||
+      resolved.compiledCompoundSlots === null ||
+      resolved.compiledCompoundSlotsBySlot === null ||
+      resolved.slotKeys === null
+    ) {
+      compileResolvedOptions(resolved);
+    }
+
+    variants = resolved.compiledVariants!;
+    compoundVariants = resolved.compiledCompoundVariants!;
+    compoundSlots = resolved.compiledCompoundSlots!;
+    compoundSlotsBySlot = resolved.compiledCompoundSlotsBySlot!;
+    keys = resolved.slotKeys!;
+    hasCompounds = compoundVariants.length > 0 || compoundSlots.length > 0;
+    mergeOverride = createLazyOverrideMerge(cn, config);
+  };
+
+  const createSlotsResult = (props?: AnyRecord): SlotsResult => {
+    const compiledVariants = variants!;
+    const compiledCompoundVariants = compoundVariants!;
+    const compiledCompoundSlotsBySlot = compoundSlotsBySlot!;
+    const slotKeys = keys!;
+    const overrideMerge = mergeOverride!;
+    const cachedCores: Record<string, string | undefined> = {};
+    const result: SlotsResult = {};
+
+    for (let i = 0; i < slotKeys.length; i++) {
+      const slotKey = slotKeys[i];
+      const compoundSlotsForKey = compiledCompoundSlotsBySlot[slotKey] ?? EMPTY_ARRAY;
+
+      const computeCore = (propsRef: AnyRecord | undefined, slotProps?: AnyRecord) => {
+        const completeProps = hasCompounds
+          ? getCompleteProps(defaultVariants, propsRef, slotProps)
+          : undefined;
+        const compoundVariantClasses = completeProps
+          ? getCompoundVariantClassesBySlot(slotKey, compiledCompoundVariants, completeProps)
+          : undefined;
+        const compoundSlotClasses = completeProps
+          ? getCompoundSlotClasses(compoundSlotsForKey, completeProps)
+          : undefined;
+
+        return cn(
+          config,
+          slots[slotKey],
+          getVariantClassNamesBySlot(
+            slotKey,
+            compiledVariants,
+            defaultVariants,
+            propsRef,
+            slotProps,
+          ),
+          compoundVariantClasses,
+          compoundSlotClasses,
+        );
+      };
+
+      // Capture parent props for this result instance (not shared mutable state).
+      cachedCores[slotKey] = computeCore(props);
+
+      result[slotKey] = (slotProps) => {
+        if (slotProps == null) return cachedCores[slotKey];
+
+        let hasVariantOverride = false;
+
+        for (const key in slotProps) {
+          if (key === "class" || key === "className") continue;
+          if (slotProps[key] !== undefined) {
+            hasVariantOverride = true;
+            break;
+          }
+        }
+
+        if (!hasVariantOverride) {
+          return overrideMerge(cachedCores[slotKey], slotProps);
+        }
+
+        const core = computeCore(props, slotProps);
+
+        return overrideMerge(core, slotProps);
+      };
+    }
+
+    return result;
+  };
 
   return ((props?: AnyRecord): RuntimeResult => {
     if (deferredError) throw deferredError;
 
-    if (slotsFns === null) {
-      if (
-        resolved.compiledVariants === null ||
-        resolved.compiledCompoundVariants === null ||
-        resolved.compiledCompoundSlots === null ||
-        resolved.compiledCompoundSlotsBySlot === null ||
-        resolved.slotKeys === null
-      ) {
-        compileResolvedOptions(resolved);
-      }
+    ensureCompiled();
 
-      const variants = resolved.compiledVariants!;
-      const compoundVariants = resolved.compiledCompoundVariants!;
-      const compoundSlots = resolved.compiledCompoundSlots!;
-      const compoundSlotsBySlot = resolved.compiledCompoundSlotsBySlot!;
-      const keys = resolved.slotKeys!;
-      const hasCompounds = compoundVariants.length > 0 || compoundSlots.length > 0;
-      let cache: ResultCache | null = null;
-      const mergeOverride = createLazyOverrideMerge(cn, config);
-      const nextSlotsFns: Record<string, (slotProps?: AnyRecord) => string | undefined> = {};
+    const propsFingerprint = buildPropsFingerprint(variantKeys, defaultVariants, props);
 
-      for (let i = 0; i < keys.length; i++) {
-        const slotKey = keys[i];
-        const compoundSlotsForKey = compoundSlotsBySlot[slotKey] ?? EMPTY_ARRAY;
-
-        const computeCore = (propsRef: AnyRecord | undefined, slotProps?: AnyRecord) => {
-          const completeProps = hasCompounds
-            ? getCompleteProps(defaultVariants, propsRef, slotProps)
-            : undefined;
-          const compoundVariantClasses = completeProps
-            ? getCompoundVariantClassesBySlot(slotKey, compoundVariants, completeProps)
-            : undefined;
-          const compoundSlotClasses = completeProps
-            ? getCompoundSlotClasses(compoundSlotsForKey, completeProps)
-            : undefined;
-
-          return cn(
-            config,
-            slots[slotKey],
-            getVariantClassNamesBySlot(slotKey, variants, defaultVariants, propsRef, slotProps),
-            compoundVariantClasses,
-            compoundSlotClasses,
-          );
-        };
-
-        nextSlotsFns[slotKey] = (slotProps) => {
-          const propsRef = currentProps;
-          let core: string | undefined;
-
-          if (!useResultCache) {
-            core = computeCore(propsRef, slotProps);
-          } else {
-            cache ??= createResultCache();
-
-            const propsFingerprint = buildPropsFingerprint(
-              variantKeys,
-              defaultVariants,
-              propsRef,
-              slotProps,
-            );
-
-            if (propsFingerprint !== null) {
-              const cacheKey = slotKey + "|" + propsFingerprint + "#" + currentCompoundsSig;
-              const cached = cache.get(cacheKey);
-
-              if (cached !== CACHE_MISS) {
-                core = cached;
-              } else {
-                core = computeCore(propsRef, slotProps);
-                cache.set(cacheKey, core);
-              }
-            } else {
-              core = computeCore(propsRef, slotProps);
-            }
-          }
-
-          return mergeOverride(core, slotProps);
-        };
-      }
-
-      slotsFns = nextSlotsFns;
+    if (propsFingerprint === null) {
+      return createSlotsResult(props);
     }
 
-    currentProps = props;
+    // Recompute each call so in-place compound metadata mutations invalidate cache keys
+    // (aligned with createVariantResolver / tv-default mutation coverage).
+    const compoundsSig = hasCompounds
+      ? buildCompoundsSignature(compoundVariants!, compoundSlots!)
+      : "";
+    const cacheKey = propsFingerprint + "#" + compoundsSig;
 
-    if (coldParentInvokesRemaining > 0) {
-      coldParentInvokesRemaining--;
-      useResultCache = false;
-      currentCompoundsSig = "";
-    } else {
-      useResultCache = true;
-      const compoundVariants = resolved.compiledCompoundVariants;
-      const compoundSlots = resolved.compiledCompoundSlots;
+    parentCache ??= createBoundedCache<SlotsResult>();
 
-      currentCompoundsSig =
-        compoundVariants &&
-        compoundSlots &&
-        (compoundVariants.length > 0 || compoundSlots.length > 0)
-          ? buildCompoundsSignature(compoundVariants, compoundSlots)
-          : "";
-    }
+    const cached = parentCache.get(cacheKey);
 
-    return slotsFns;
+    if (cached !== CACHE_MISS) return cached;
+
+    const next = createSlotsResult(props);
+
+    parentCache.set(cacheKey, next);
+
+    return next;
   }) as RuntimeComponent;
 };
 

--- a/src/internal/class-resolver.ts
+++ b/src/internal/class-resolver.ts
@@ -302,18 +302,20 @@ const createVariantResolver = (resolved: ResolvedOptions, cn: CnAdapter): Runtim
 };
 
 type SlotsResult = Record<string, (slotProps?: AnyRecord) => string | undefined>;
+type SlotComputer = (propsRef?: AnyRecord, slotProps?: AnyRecord) => string | undefined;
 
 const createSlotsResolver = (resolved: ResolvedOptions, cn: CnAdapter): RuntimeComponent => {
   const {config, defaultVariants, deferredError, slots, variantKeys} = resolved;
 
-  let variants: CompiledVariant[] | null = null;
   let compoundVariants: CompiledCompoundVariant[] | null = null;
   let compoundSlots: CompiledCompoundSlot[] | null = null;
-  let compoundSlotsBySlot: Record<string, CompiledCompoundSlot[]> | null = null;
   let keys: string[] | null = null;
+  let slotComputers: SlotComputer[] | null = null;
   let hasCompounds = false;
   let mergeOverride: ReturnType<typeof createLazyOverrideMerge> | null = null;
   let parentCache: ReturnType<typeof createBoundedCache<SlotsResult>> | null = null;
+  // First parent invoke skips fingerprint/cache setup (lifecycle create+call once).
+  let coldParentInvokesRemaining = 1;
 
   const ensureCompiled = () => {
     if (keys !== null) return;
@@ -328,34 +330,27 @@ const createSlotsResolver = (resolved: ResolvedOptions, cn: CnAdapter): RuntimeC
       compileResolvedOptions(resolved);
     }
 
-    variants = resolved.compiledVariants!;
+    const variants = resolved.compiledVariants!;
     compoundVariants = resolved.compiledCompoundVariants!;
     compoundSlots = resolved.compiledCompoundSlots!;
-    compoundSlotsBySlot = resolved.compiledCompoundSlotsBySlot!;
+    const compoundSlotsBySlot = resolved.compiledCompoundSlotsBySlot!;
     keys = resolved.slotKeys!;
     hasCompounds = compoundVariants.length > 0 || compoundSlots.length > 0;
     mergeOverride = createLazyOverrideMerge(cn, config);
-  };
 
-  const createSlotsResult = (props?: AnyRecord): SlotsResult => {
-    const compiledVariants = variants!;
-    const compiledCompoundVariants = compoundVariants!;
-    const compiledCompoundSlotsBySlot = compoundSlotsBySlot!;
-    const slotKeys = keys!;
-    const overrideMerge = mergeOverride!;
-    const cachedCores: Record<string, string | undefined> = {};
-    const result: SlotsResult = {};
+    // One computer per slot for the lifetime of this tv() instance.
+    const computers: SlotComputer[] = new Array(keys.length);
 
-    for (let i = 0; i < slotKeys.length; i++) {
-      const slotKey = slotKeys[i];
-      const compoundSlotsForKey = compiledCompoundSlotsBySlot[slotKey] ?? EMPTY_ARRAY;
+    for (let i = 0; i < keys.length; i++) {
+      const slotKey = keys[i];
+      const compoundSlotsForKey = compoundSlotsBySlot[slotKey] ?? EMPTY_ARRAY;
 
-      const computeCore = (propsRef: AnyRecord | undefined, slotProps?: AnyRecord) => {
+      computers[i] = (propsRef, slotProps) => {
         const completeProps = hasCompounds
           ? getCompleteProps(defaultVariants, propsRef, slotProps)
           : undefined;
         const compoundVariantClasses = completeProps
-          ? getCompoundVariantClassesBySlot(slotKey, compiledCompoundVariants, completeProps)
+          ? getCompoundVariantClassesBySlot(slotKey, compoundVariants!, completeProps)
           : undefined;
         const compoundSlotClasses = completeProps
           ? getCompoundSlotClasses(compoundSlotsForKey, completeProps)
@@ -364,23 +359,29 @@ const createSlotsResolver = (resolved: ResolvedOptions, cn: CnAdapter): RuntimeC
         return cn(
           config,
           slots[slotKey],
-          getVariantClassNamesBySlot(
-            slotKey,
-            compiledVariants,
-            defaultVariants,
-            propsRef,
-            slotProps,
-          ),
+          getVariantClassNamesBySlot(slotKey, variants, defaultVariants, propsRef, slotProps),
           compoundVariantClasses,
           compoundSlotClasses,
         );
       };
+    }
 
+    slotComputers = computers;
+  };
+
+  const createSlotsResult = (props?: AnyRecord): SlotsResult => {
+    const slotKeys = keys!;
+    const computers = slotComputers!;
+    const overrideMerge = mergeOverride!;
+    const result: SlotsResult = {};
+
+    for (let i = 0; i < slotKeys.length; i++) {
+      const compute = computers[i];
       // Capture parent props for this result instance (not shared mutable state).
-      cachedCores[slotKey] = computeCore(props);
+      const core = compute(props);
 
-      result[slotKey] = (slotProps) => {
-        if (slotProps == null) return cachedCores[slotKey];
+      result[slotKeys[i]] = (slotProps) => {
+        if (slotProps == null) return core;
 
         let hasVariantOverride = false;
 
@@ -393,12 +394,10 @@ const createSlotsResolver = (resolved: ResolvedOptions, cn: CnAdapter): RuntimeC
         }
 
         if (!hasVariantOverride) {
-          return overrideMerge(cachedCores[slotKey], slotProps);
+          return overrideMerge(core, slotProps);
         }
 
-        const core = computeCore(props, slotProps);
-
-        return overrideMerge(core, slotProps);
+        return overrideMerge(compute(props, slotProps), slotProps);
       };
     }
 
@@ -409,6 +408,13 @@ const createSlotsResolver = (resolved: ResolvedOptions, cn: CnAdapter): RuntimeC
     if (deferredError) throw deferredError;
 
     ensureCompiled();
+
+    // Cold path: avoid fingerprint/compoundsSig/Map overhead on first invoke.
+    if (coldParentInvokesRemaining > 0) {
+      coldParentInvokesRemaining--;
+
+      return createSlotsResult(props);
+    }
 
     const propsFingerprint = buildPropsFingerprint(variantKeys, defaultVariants, props);
 


### PR DESCRIPTION
Fixes https://github.com/heroui-inc/tailwind-variants/issues/304

<!-- Thank you for contributing! -->

### Description

In 3.3.0, slot `tv()` calls reused one slots object and a shared `currentProps`, so interleaved invocations cross-contaminated class names and broke reference-equality reactivity (e.g. Svelte 5 `$derived`).

This PR makes each parent call return an independent slots result that captures its own props, while keeping a bounded parent-level cache for repeated props. The first (cold) parent invoke skips cache setup so the lifecycle/slots benchmark does not regress.

### Additional context

- Correctness coverage: `src/__tests__/tv-slots-independence.test.ts` (tv + lite)
- Same-props result identity reuse starts after the cold first invoke (intentional perf tradeoff)
- Benchmarks: lifecycle/slots recovered to ~3.3.0 levels; invocation/slots is faster via parent cache

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Performance impact

<!--
Required for changes to runtime code, benchmark workloads, build output, or runtime dependencies.
Run the full `pnpm benchmark`; `--quick` is only a smoke test.
Treat differences within ±5% as noise. Re-run larger regressions on the same machine and explain
every confirmed regression, including the affected scenario, delta, absolute throughput, and
trade-off. See benchmark/README.md.
-->

- [x] This change is not performance-sensitive.
- [x] I ran the full `pnpm benchmark` suite and reviewed the current TV versus released TV results.
- [x] Any confirmed regression above 5% is documented and intentionally bounded.

<!-- Benchmark summary, confirmed regressions, and rationale (if applicable): -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/heroui-inc/tailwind-variants/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/heroui-inc/tailwind-variants/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Confirm that performance-sensitive changes follow the [benchmark requirements](https://github.com/heroui-inc/tailwind-variants/blob/main/CONTRIBUTING.md#benchmark-requirements).
